### PR TITLE
Update memoization implementation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,11 @@
+require 'bundler/setup'
+require 'rake/testtask'
+
+Rake::TestTask.new do |test|
+  test.pattern = 'test/**/*_spec.rb'
+  test.verbose = true
+end
+
+task :default => [] do
+  Rake::Task[:test].invoke
+end

--- a/bogo.gemspec
+++ b/bogo.gemspec
@@ -14,5 +14,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'multi_json'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'minitest'
+  s.add_development_dependency 'rake', '~> 10'
   s.files = Dir['lib/**/*'] + %w(bogo.gemspec README.md CHANGELOG.md CONTRIBUTING.md LICENSE)
 end

--- a/test/spec.rb
+++ b/test/spec.rb
@@ -1,5 +1,2 @@
 require 'bogo'
-
-Dir.glob(File.join(File.dirname(__FILE__), 'specs/*_spec.rb')).each do |path|
-  require File.expand_path(path)
-end
+require 'minitest/autorun'

--- a/test/specs/animal_strings_spec.rb
+++ b/test/specs/animal_strings_spec.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+require_relative '../spec'
 
 describe Bogo::AnimalStrings do
 

--- a/test/specs/constants_spec.rb
+++ b/test/specs/constants_spec.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+require_relative '../spec'
 
 class BogoConstTop
   include Bogo::Constants

--- a/test/specs/ephemeral_file_spec.rb
+++ b/test/specs/ephemeral_file_spec.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+require_relative '../spec'
 
 describe Bogo::EphemeralFile do
 

--- a/test/specs/lazy_spec.rb
+++ b/test/specs/lazy_spec.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+require_relative '../spec'
 
 describe Bogo::Lazy do
 

--- a/test/specs/memoization_spec.rb
+++ b/test/specs/memoization_spec.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+require_relative '../spec'
 
 describe Bogo::Memoization do
 
@@ -41,6 +41,13 @@ describe Bogo::Memoization do
       end.join
       a.memoize(:x){ :foobar }.must_equal :fubar
       b.memoize(:x){ :foobar }.must_equal :feebar
+    end
+
+    it 'should identify memoized value' do
+      a = @klass.new
+      a.memoize(:x){ :fubar }
+      a.memoized?(:x).must_equal true
+      a.memoized?(:y).must_equal false
     end
 
   end
@@ -89,6 +96,13 @@ describe Bogo::Memoization do
       b.memoize(:x, true){ :foobar }.must_equal :fubar
     end
 
+    it 'should identify memoized value' do
+      a = @klass.new
+      a.memoize(:x, true){ :fubar }
+      a.memoized?(:x, true).must_equal true
+      a.memoized?(:y, true).must_equal false
+    end
+
   end
 
   describe 'Global memoization' do
@@ -134,6 +148,13 @@ describe Bogo::Memoization do
       end.join
       a.memoize(:x, :global){ :foobar }.must_equal :fubar
       b.memoize(:x, :global){ :foobar }.must_equal :fubar
+    end
+
+    it 'should identify memoized value' do
+      a = @klass.new
+      a.memoize(:x, :global){ :fubar }
+      a.memoized?(:x, :global).must_equal true
+      a.memoized?(:y, :global).must_equal false
     end
 
   end

--- a/test/specs/priority_queue_spec.rb
+++ b/test/specs/priority_queue_spec.rb
@@ -1,5 +1,4 @@
-require 'bogo'
-require 'minitest/autorun'
+require_relative '../spec'
 
 describe Bogo::PriorityQueue do
 

--- a/test/specs/retry_spec.rb
+++ b/test/specs/retry_spec.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+require_relative '../spec'
 
 describe Bogo::Retry do
 

--- a/test/specs/smash_spec.rb
+++ b/test/specs/smash_spec.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+require_relative '../spec'
 
 describe Bogo::Smash do
 

--- a/test/specs/utility_spec.rb
+++ b/test/specs/utility_spec.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+require_relative '../spec'
 
 describe Bogo::Utility do
 


### PR DESCRIPTION
Refactor memoization helper to be more self contained. Fixes
deprecation warnings generated on Ruby 2.3