### PR TITLE
speed up key lookup

### DIFF
--- a/lib/bogo/smash.rb
+++ b/lib/bogo/smash.rb
@@ -42,15 +42,22 @@ module Bogo
     end
 
     # Get value at given path
+    # Very hot code, so optimizing with dig on ruby 2.3+
     #
     # @param args [String, Symbol] key path to walk
     # @return [Object, NoValue]
-    def retrieve(*args)
-      args.inject(self) do |memo, key|
-        if(memo.is_a?(Hash) && memo.to_smash.has_key?(key.to_s))
-          memo.to_smash[key]
-        else
-          NO_VALUE
+    if {}.respond_to?(:dig)
+      def retrieve(*args)
+        dig(*args) || NO_VALUE
+      end
+    else
+      def retrieve(*args)
+        args.inject(self) do |memo, key|
+          if(memo.is_a?(Hash))
+            memo[key]
+          else
+            NO_VALUE
+          end
         end
       end
     end


### PR DESCRIPTION
@chrisroberts 

updated to sfn 3 and everything got 10x slower ... stackproffed my way into retrieve being the main cause ... could also be that retrieve got called needlessly ... but this seems to help taking it from 10x slower to 0.2x slower

FYI putting this into bin/sfn and then checking the output on our giant project ...
```
    def flamegraph(name: 'test', **options, &block)
      options[:raw] = true
      options[:mode] ||= :wall

      file = "#{name}.dump"
      time_taken = nil
      GC.disable
      dump = StackProf.run(options) do
        time_taken = Benchmark.realtime(&block)
      end
      GC.enable
      report = StackProf::Report.new(dump)
      File.open(file, 'w+') { |f| report.print_flamegraph(f) }
      spec = Gem::Specification.find_by_name("stackprof")
      puts "open in your browser: file://#{spec.gem_dir}/lib/stackprof/flamegraph/viewer.html?data=#{File.expand_path(file)}"
      time_taken
    end
```